### PR TITLE
Issue #1: Url counter plugin

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,7 @@ import Config
 config :irc_bot,
   ecto_repos: [IrcBot.Repo],
   generators: [timestamp_type: :utc_datetime],
-  plugins: [IrcBot.Plugins.Karma, IrcBot.Plugins.Echo]
+  plugins: [IrcBot.Plugins.Karma, IrcBot.Plugins.Echo, IrcBot.Plugins.UrlCounter]
 
 # Configure the endpoint
 config :irc_bot, IrcBotWeb.Endpoint,

--- a/lib/irc_bot/plugins/url_counter.ex
+++ b/lib/irc_bot/plugins/url_counter.ex
@@ -1,0 +1,62 @@
+defmodule IrcBot.Plugins.UrlCounter do
+  @moduledoc """
+  URL counter plugin for the IRC bot.
+
+  Tracks URLs shared in IRC channels, storing them in the database.
+  Broadcasts updates via PubSub for real-time dashboard updates.
+
+  Any message containing an http or https URL will be recorded.
+  """
+
+  @behaviour IrcBot.Plugin
+
+  alias IrcBot.IRC.Message
+  alias IrcBot.Plugins.UrlCounter.{Parser, Store}
+
+  @impl true
+  @spec name() :: String.t()
+  def name, do: "url_counter"
+
+  @impl true
+  @spec description() :: String.t()
+  def description, do: "Track URLs shared in chat"
+
+  @impl true
+  @spec init(keyword()) :: {:ok, map()}
+  def init(_opts), do: {:ok, %{}}
+
+  @impl true
+  @spec handles?(Message.t()) :: boolean()
+  def handles?(%{type: :privmsg, text: text}) do
+    Parser.extract_urls(text) != []
+  end
+
+  def handles?(_), do: false
+
+  @impl true
+  @spec handle_message(Message.t(), map()) :: {:noreply, map()}
+  def handle_message(%{nick: nick, channel: channel, text: text}, state) do
+    urls = Parser.extract_urls(text)
+
+    for url <- urls do
+      domain = Parser.extract_domain(url)
+
+      if domain do
+        Store.record_url(url, domain, nick, channel)
+        broadcast_url_update(url, domain, nick, channel)
+      end
+    end
+
+    {:noreply, state}
+  end
+
+  defp broadcast_url_update(url, domain, nick, channel) do
+    Phoenix.PubSub.broadcast(IrcBot.PubSub, "url:updates", %{
+      event: :url_shared,
+      url: url,
+      domain: domain,
+      nick: nick,
+      channel: channel
+    })
+  end
+end

--- a/lib/irc_bot/plugins/url_counter/parser.ex
+++ b/lib/irc_bot/plugins/url_counter/parser.ex
@@ -1,0 +1,30 @@
+defmodule IrcBot.Plugins.UrlCounter.Parser do
+  @moduledoc """
+  Extracts URLs from IRC message text.
+
+  Supports http and https URLs.
+  """
+
+  @url_regex ~r{https?://[^\s<>"]+}i
+
+  @doc "Extracts all URLs from the given text."
+  @spec extract_urls(String.t()) :: [String.t()]
+  def extract_urls(text) do
+    @url_regex
+    |> Regex.scan(text)
+    |> List.flatten()
+  end
+
+  @doc "Extracts the domain (host) from a URL. Returns nil if parsing fails."
+  @spec extract_domain(String.t()) :: String.t() | nil
+  def extract_domain(url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) and host != "" ->
+        host
+        |> String.downcase()
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/lib/irc_bot/plugins/url_counter/schema.ex
+++ b/lib/irc_bot/plugins/url_counter/schema.ex
@@ -1,0 +1,26 @@
+defmodule IrcBot.Plugins.UrlCounter.Schema do
+  @moduledoc """
+  Ecto schema for URL entries.
+
+  Each entry tracks a URL that was shared in a specific channel by a user.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "url_entries" do
+    field :url, :string
+    field :domain, :string
+    field :nick, :string
+    field :channel, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc "Changeset for creating a URL entry."
+  def changeset(entry, attrs) do
+    entry
+    |> cast(attrs, [:url, :domain, :nick, :channel])
+    |> validate_required([:url, :domain, :nick, :channel])
+  end
+end

--- a/lib/irc_bot/plugins/url_counter/store.ex
+++ b/lib/irc_bot/plugins/url_counter/store.ex
@@ -1,0 +1,46 @@
+defmodule IrcBot.Plugins.UrlCounter.Store do
+  @moduledoc """
+  Database operations for URL tracking.
+
+  Stores URLs shared in IRC channels and provides queries for
+  recent URLs and top domains.
+  """
+
+  import Ecto.Query
+
+  alias IrcBot.Plugins.UrlCounter.Schema
+  alias IrcBot.Repo
+
+  @doc "Records a URL shared in a channel."
+  @spec record_url(String.t(), String.t(), String.t(), String.t()) :: {:ok, Schema.t()}
+  def record_url(url, domain, nick, channel) do
+    %Schema{url: url, domain: domain, nick: nick, channel: channel}
+    |> Repo.insert()
+  end
+
+  @doc "Returns the most recently shared URLs."
+  @spec recent_urls(pos_integer()) :: [Schema.t()]
+  def recent_urls(limit \\ 10) do
+    Schema
+    |> order_by([u], desc: u.inserted_at, desc: u.id)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
+  @doc "Returns the top domains by number of URLs shared."
+  @spec top_domains(pos_integer()) :: [{String.t(), integer()}]
+  def top_domains(limit \\ 10) do
+    Schema
+    |> group_by([u], u.domain)
+    |> order_by([u], desc: count(u.id))
+    |> limit(^limit)
+    |> select([u], {u.domain, count(u.id)})
+    |> Repo.all()
+  end
+
+  @doc "Returns the total number of tracked URLs."
+  @spec total_count() :: integer()
+  def total_count do
+    Repo.aggregate(Schema, :count)
+  end
+end

--- a/lib/irc_bot_web/live/urls_live.ex
+++ b/lib/irc_bot_web/live/urls_live.ex
@@ -1,0 +1,117 @@
+defmodule IrcBotWeb.UrlsLive do
+  @moduledoc """
+  Dashboard page showing recent URLs and top domains.
+  """
+
+  use IrcBotWeb, :live_view
+
+  alias IrcBot.Plugins.UrlCounter.Store
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(IrcBot.PubSub, "url:updates")
+    end
+
+    {:ok,
+     assign(socket,
+       page_title: "URLs",
+       recent_urls: Store.recent_urls(25),
+       top_domains: Store.top_domains(10),
+       total_count: Store.total_count()
+     )}
+  end
+
+  @impl true
+  def handle_info(%{event: :url_shared}, socket) do
+    {:noreply,
+     assign(socket,
+       recent_urls: Store.recent_urls(25),
+       top_domains: Store.top_domains(10),
+       total_count: Store.total_count()
+     )}
+  end
+
+  @impl true
+  def handle_info(_msg, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <div class="space-y-6">
+        <div class="flex items-center justify-between">
+          <h1 class="text-2xl font-bold">URLs</h1>
+          <div class="flex gap-2 items-center">
+            <span class="badge badge-lg badge-info">{@total_count} total</span>
+            <.link navigate={~p"/"} class="btn btn-sm btn-outline">
+              Back to Dashboard
+            </.link>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <%!-- Recent URLs --%>
+          <div class="lg:col-span-2">
+            <div class="card bg-base-200 shadow-lg">
+              <div class="card-body">
+                <h2 class="card-title">Recent URLs</h2>
+                <div :if={@recent_urls == []} class="text-base-content/50 italic text-center py-8">
+                  No URLs shared yet.
+                </div>
+                <div class="overflow-x-auto">
+                  <table :if={@recent_urls != []} class="table">
+                    <thead>
+                      <tr>
+                        <th>URL</th>
+                        <th>Shared by</th>
+                        <th>Channel</th>
+                        <th>When</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr :for={entry <- @recent_urls}>
+                        <td class="max-w-xs truncate">
+                          <span class="font-mono text-sm" title={entry.url}>{entry.url}</span>
+                        </td>
+                        <td class="font-medium">{entry.nick}</td>
+                        <td>{entry.channel}</td>
+                        <td class="text-sm text-base-content/60">
+                          {Calendar.strftime(entry.inserted_at, "%Y-%m-%d %H:%M")}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <%!-- Top Domains --%>
+          <div>
+            <div class="card bg-base-200 shadow-lg">
+              <div class="card-body">
+                <h2 class="card-title">Top Domains</h2>
+                <div :if={@top_domains == []} class="text-base-content/50 italic">
+                  No domains tracked yet.
+                </div>
+                <div class="space-y-2">
+                  <div
+                    :for={{domain, count} <- @top_domains}
+                    class="flex justify-between items-center"
+                  >
+                    <span class="font-medium font-mono text-sm">{domain}</span>
+                    <span class="badge badge-primary badge-lg">{count}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/irc_bot_web/router.ex
+++ b/lib/irc_bot_web/router.ex
@@ -19,6 +19,7 @@ defmodule IrcBotWeb.Router do
 
     live "/", DashboardLive
     live "/karma", KarmaLive
+    live "/urls", UrlsLive
     live "/channels/:channel", ChannelLive
   end
 

--- a/priv/repo/migrations/20260211104024_create_url_entries.exs
+++ b/priv/repo/migrations/20260211104024_create_url_entries.exs
@@ -1,0 +1,17 @@
+defmodule IrcBot.Repo.Migrations.CreateUrlEntries do
+  use Ecto.Migration
+
+  def change do
+    create table(:url_entries) do
+      add :url, :string, null: false
+      add :domain, :string, null: false
+      add :nick, :string, null: false
+      add :channel, :string, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:url_entries, [:channel])
+    create index(:url_entries, [:domain])
+  end
+end

--- a/test/irc_bot/plugins/url_counter/parser_test.exs
+++ b/test/irc_bot/plugins/url_counter/parser_test.exs
@@ -1,0 +1,63 @@
+defmodule IrcBot.Plugins.UrlCounter.ParserTest do
+  use ExUnit.Case, async: true
+
+  alias IrcBot.Plugins.UrlCounter.Parser
+
+  describe "extract_urls/1" do
+    test "extracts a single HTTP URL" do
+      assert ["http://example.com"] = Parser.extract_urls("check http://example.com out")
+    end
+
+    test "extracts a single HTTPS URL" do
+      assert ["https://example.com"] = Parser.extract_urls("visit https://example.com")
+    end
+
+    test "extracts multiple URLs" do
+      text = "see https://foo.com and http://bar.com"
+      assert ["https://foo.com", "http://bar.com"] = Parser.extract_urls(text)
+    end
+
+    test "extracts URLs with paths and query strings" do
+      url = "https://example.com/path?q=hello&lang=en"
+      assert [^url] = Parser.extract_urls("link: #{url}")
+    end
+
+    test "returns empty list when no URLs" do
+      assert [] = Parser.extract_urls("just some text")
+    end
+
+    test "ignores non-http protocols" do
+      assert [] = Parser.extract_urls("ftp://example.com")
+    end
+
+    test "handles URL at start of message" do
+      assert ["https://example.com"] = Parser.extract_urls("https://example.com is cool")
+    end
+
+    test "handles URL at end of message" do
+      assert ["https://example.com"] = Parser.extract_urls("check this https://example.com")
+    end
+  end
+
+  describe "extract_domain/1" do
+    test "extracts domain from HTTPS URL" do
+      assert "example.com" = Parser.extract_domain("https://example.com/path")
+    end
+
+    test "extracts domain from HTTP URL" do
+      assert "example.com" = Parser.extract_domain("http://example.com")
+    end
+
+    test "downcases domain" do
+      assert "example.com" = Parser.extract_domain("https://EXAMPLE.COM/path")
+    end
+
+    test "extracts subdomain" do
+      assert "sub.example.com" = Parser.extract_domain("https://sub.example.com")
+    end
+
+    test "returns nil for invalid URL" do
+      assert nil == Parser.extract_domain("not a url")
+    end
+  end
+end

--- a/test/irc_bot/plugins/url_counter/store_test.exs
+++ b/test/irc_bot/plugins/url_counter/store_test.exs
@@ -1,0 +1,75 @@
+defmodule IrcBot.Plugins.UrlCounter.StoreTest do
+  use IrcBot.DataCase, async: false
+
+  alias IrcBot.Plugins.UrlCounter.Store
+
+  describe "record_url/4" do
+    test "inserts a URL entry" do
+      {:ok, entry} = Store.record_url("https://example.com", "example.com", "alice", "#test")
+      assert entry.url == "https://example.com"
+      assert entry.domain == "example.com"
+      assert entry.nick == "alice"
+      assert entry.channel == "#test"
+    end
+  end
+
+  describe "recent_urls/1" do
+    test "returns empty list when no URLs" do
+      assert [] = Store.recent_urls()
+    end
+
+    test "returns URLs ordered by most recent first" do
+      Store.record_url("https://first.com", "first.com", "alice", "#test")
+      Store.record_url("https://second.com", "second.com", "bob", "#test")
+
+      urls = Store.recent_urls()
+      assert [%{url: "https://second.com"}, %{url: "https://first.com"}] = urls
+    end
+
+    test "respects limit" do
+      Store.record_url("https://a.com", "a.com", "alice", "#test")
+      Store.record_url("https://b.com", "b.com", "bob", "#test")
+      Store.record_url("https://c.com", "c.com", "charlie", "#test")
+
+      urls = Store.recent_urls(2)
+      assert length(urls) == 2
+    end
+  end
+
+  describe "top_domains/1" do
+    test "returns empty list when no URLs" do
+      assert [] = Store.top_domains()
+    end
+
+    test "returns domains ordered by count descending" do
+      Store.record_url("https://example.com/1", "example.com", "alice", "#test")
+      Store.record_url("https://example.com/2", "example.com", "bob", "#test")
+      Store.record_url("https://other.com", "other.com", "alice", "#test")
+
+      domains = Store.top_domains()
+      assert [{"example.com", 2}, {"other.com", 1}] = domains
+    end
+
+    test "respects limit" do
+      Store.record_url("https://a.com", "a.com", "alice", "#test")
+      Store.record_url("https://b.com", "b.com", "bob", "#test")
+      Store.record_url("https://c.com", "c.com", "charlie", "#test")
+
+      domains = Store.top_domains(2)
+      assert length(domains) == 2
+    end
+  end
+
+  describe "total_count/0" do
+    test "returns 0 when no URLs" do
+      assert 0 = Store.total_count()
+    end
+
+    test "returns total number of URLs" do
+      Store.record_url("https://a.com", "a.com", "alice", "#test")
+      Store.record_url("https://b.com", "b.com", "bob", "#test")
+
+      assert 2 = Store.total_count()
+    end
+  end
+end

--- a/test/irc_bot/plugins/url_counter_test.exs
+++ b/test/irc_bot/plugins/url_counter_test.exs
@@ -1,0 +1,78 @@
+defmodule IrcBot.Plugins.UrlCounterTest do
+  use IrcBot.DataCase, async: false
+
+  alias IrcBot.IRC.Message
+  alias IrcBot.Plugins.UrlCounter
+
+  setup do
+    {:ok, state} = UrlCounter.init([])
+    %{state: state}
+  end
+
+  describe "handles?/1" do
+    test "returns true for message with URL" do
+      msg =
+        Message.new(
+          type: :privmsg,
+          nick: "alice",
+          channel: "#test",
+          text: "check https://example.com"
+        )
+
+      assert UrlCounter.handles?(msg)
+    end
+
+    test "returns false for message without URL" do
+      msg = Message.new(type: :privmsg, nick: "alice", channel: "#test", text: "hello world")
+      refute UrlCounter.handles?(msg)
+    end
+
+    test "returns false for non-privmsg" do
+      msg = Message.new(type: :join, nick: "alice", channel: "#test", text: "https://example.com")
+      refute UrlCounter.handles?(msg)
+    end
+  end
+
+  describe "handle_message/2" do
+    test "records URL and returns noreply", %{state: state} do
+      msg =
+        Message.new(
+          type: :privmsg,
+          nick: "alice",
+          channel: "#test",
+          text: "see https://example.com"
+        )
+
+      assert {:noreply, ^state} = UrlCounter.handle_message(msg, state)
+
+      urls = IrcBot.Plugins.UrlCounter.Store.recent_urls()
+      assert [%{url: "https://example.com", domain: "example.com", nick: "alice"}] = urls
+    end
+
+    test "records multiple URLs from one message", %{state: state} do
+      msg =
+        Message.new(
+          type: :privmsg,
+          nick: "alice",
+          channel: "#test",
+          text: "see https://foo.com and https://bar.com"
+        )
+
+      UrlCounter.handle_message(msg, state)
+
+      urls = IrcBot.Plugins.UrlCounter.Store.recent_urls()
+      assert length(urls) == 2
+    end
+
+    test "broadcasts url:updates on URL share", %{state: state} do
+      Phoenix.PubSub.subscribe(IrcBot.PubSub, "url:updates")
+
+      msg =
+        Message.new(type: :privmsg, nick: "alice", channel: "#test", text: "https://example.com")
+
+      UrlCounter.handle_message(msg, state)
+
+      assert_receive %{event: :url_shared, url: "https://example.com", domain: "example.com"}
+    end
+  end
+end

--- a/test/irc_bot_web/live/urls_live_test.exs
+++ b/test/irc_bot_web/live/urls_live_test.exs
@@ -1,0 +1,58 @@
+defmodule IrcBotWeb.UrlsLiveTest do
+  use IrcBotWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias IrcBot.Plugins.UrlCounter.Store
+
+  test "renders URLs page", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/urls")
+
+    assert html =~ "URLs"
+    assert html =~ "Back to Dashboard"
+  end
+
+  test "shows empty state when no URLs", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/urls")
+    assert html =~ "No URLs shared yet"
+  end
+
+  test "displays URL entries", %{conn: conn} do
+    Store.record_url("https://example.com/page", "example.com", "alice", "#test")
+    Store.record_url("https://other.com", "other.com", "bob", "#dev")
+
+    {:ok, _view, html} = live(conn, "/urls")
+
+    assert html =~ "example.com/page"
+    assert html =~ "other.com"
+    assert html =~ "alice"
+    assert html =~ "bob"
+  end
+
+  test "displays top domains", %{conn: conn} do
+    Store.record_url("https://example.com/1", "example.com", "alice", "#test")
+    Store.record_url("https://example.com/2", "example.com", "bob", "#test")
+
+    {:ok, _view, html} = live(conn, "/urls")
+
+    assert html =~ "Top Domains"
+    assert html =~ "example.com"
+  end
+
+  test "updates on url_shared broadcast", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/urls")
+
+    Store.record_url("https://new-url.com", "new-url.com", "charlie", "#test")
+
+    Phoenix.PubSub.broadcast(IrcBot.PubSub, "url:updates", %{
+      event: :url_shared,
+      url: "https://new-url.com",
+      domain: "new-url.com",
+      nick: "charlie",
+      channel: "#test"
+    })
+
+    html = render(view)
+    assert html =~ "new-url.com"
+  end
+end


### PR DESCRIPTION
## Issue

Closes #1

## Summary

Automated implementation of: **Url counter plugin**

Make a plugin that counts URLs that are being sent in the chat. 

The dashboard should show which urls were sent last. 

Keep track of the most sent domains too. 

---

> This PR was generated by `scripts/work_issue.sh` using Claude Code.
> Please review carefully before merging.